### PR TITLE
feat!: update supported Node.js versions to `^22.12 || >=24`

### DIFF
--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: lts/*
       - name: Install Packages
         run: npm i
       - name: Lint
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [22.12.0, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/syntax/build-syntax-resolver.js
+++ b/lib/syntax/build-syntax-resolver.js
@@ -122,7 +122,6 @@ function loadFromString(syntax) {
 		const m = require("module");
 		const cwd = process.cwd();
 		const relativeTo = path.join(cwd, "__placeholder__.js");
-		// eslint-disable-next-line node/no-unsupported-features/node-builtins -- ignore
 		return m.createRequire(relativeTo)(syntax);
 	} catch (error) {
 		if (!isModuleNotFoundError(error)) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "PostCSS syntax for parsing Markdown",
   "engines": {
-    "node": "^12 || >=14"
+    "node": "^22.12 || >=24"
   },
   "main": "./lib/index.js",
   "files": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,18 @@
 {
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges",
-    ":disableDependencyDashboard"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":preserveSemverRanges"],
   "packageRules": [
     {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "depTypeList": ["devDependencies"],
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions", "devcontainer"],
       "automerge": true
     }
-  ],
-  "includeForks": true
+  ]
 }

--- a/test/__snapshots__/ast.js.snap
+++ b/test/__snapshots__/ast.js.snap
@@ -4,40 +4,6 @@ exports[`AST tests block-in-blockquote.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "  a {
-   color: red;
-  }
-",
-      "file": "/block-in-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "    a {
-      color: red;
-    }
-",
-      "file": "/block-in-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "  a {
-    color: red;
-  }
-",
-      "file": "/block-in-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "    a {
-
-      color: red;
-
-      }
-",
-      "file": "/block-in-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Header
 
 ## Blockquote
@@ -79,6 +45,40 @@ Object {
       "file": "/block-in-blockquote.md",
       "hasBOM": false,
     },
+    Object {
+      "css": "  a {
+   color: red;
+  }
+",
+      "file": "/block-in-blockquote.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "    a {
+      color: red;
+    }
+",
+      "file": "/block-in-blockquote.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "  a {
+    color: red;
+  }
+",
+      "file": "/block-in-blockquote.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "    a {
+
+      color: red;
+
+      }
+",
+      "file": "/block-in-blockquote.md",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -103,7 +103,7 @@ Object {
                   "line": 7,
                   "offset": 53,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 4,
                   "line": 7,
@@ -128,7 +128,7 @@ Object {
               "line": 8,
               "offset": 57,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 3,
               "line": 6,
@@ -164,7 +164,7 @@ Object {
           "line": 9,
           "offset": 59,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 6,
@@ -195,7 +195,7 @@ Object {
                   "line": 15,
                   "offset": 124,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 7,
                   "line": 15,
@@ -220,7 +220,7 @@ Object {
               "line": 16,
               "offset": 130,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 5,
               "line": 14,
@@ -256,7 +256,7 @@ Object {
           "line": 17,
           "offset": 132,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 14,
@@ -287,7 +287,7 @@ Object {
                   "line": 24,
                   "offset": 206,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 5,
                   "line": 24,
@@ -312,7 +312,7 @@ Object {
               "line": 25,
               "offset": 210,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 3,
               "line": 23,
@@ -352,7 +352,7 @@ Object {
           "line": 26,
           "offset": 212,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 23,
@@ -384,7 +384,7 @@ Object {
                   "line": 34,
                   "offset": 296,
                 },
-                "inputId": 0,
+                "inputId": 4,
                 "start": Object {
                   "column": 7,
                   "line": 34,
@@ -410,7 +410,7 @@ Object {
               "line": 36,
               "offset": 308,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 5,
               "line": 32,
@@ -451,7 +451,7 @@ Object {
           "line": 37,
           "offset": 310,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 1,
           "line": 32,
@@ -477,6 +477,52 @@ Object {
 exports[`AST tests block-in-list.md ast 1`] = `
 Object {
   "inputs": Array [
+    Object {
+      "css": "# Header
+
+## Unordered List
+
+- \`\`\`css
+  a {
+   color: red;
+
+  }
+  \`\`\`
+
++ \`\`\`css
+  .b { color: red; }
+
+  \`\`\`
+
+* \`\`\`css
+
+  .c { color: red; }
+
+  \`\`\`
+
+## Ordered List
+
+1. \`\`\`css
+   .d {
+   color: red;
+
+   }
+   \`\`\`
+
+1. \`\`\`css
+   .e { color: red; }
+
+   \`\`\`
+
+2. \`\`\`css
+
+   .f { color: red; }
+
+   \`\`\`
+",
+      "file": "/block-in-list.md",
+      "hasBOM": false,
+    },
     Object {
       "css": "  a {
    color: red;
@@ -525,52 +571,6 @@ Object {
       "file": "/block-in-list.md",
       "hasBOM": false,
     },
-    Object {
-      "css": "# Header
-
-## Unordered List
-
-- \`\`\`css
-  a {
-   color: red;
-
-  }
-  \`\`\`
-
-+ \`\`\`css
-  .b { color: red; }
-
-  \`\`\`
-
-* \`\`\`css
-
-  .c { color: red; }
-
-  \`\`\`
-
-## Ordered List
-
-1. \`\`\`css
-   .d {
-   color: red;
-
-   }
-   \`\`\`
-
-1. \`\`\`css
-   .e { color: red; }
-
-   \`\`\`
-
-2. \`\`\`css
-
-   .f { color: red; }
-
-   \`\`\`
-",
-      "file": "/block-in-list.md",
-      "hasBOM": false,
-    },
   ],
   "nodes": Array [
     Object {
@@ -595,7 +595,7 @@ Object {
                   "line": 7,
                   "offset": 57,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 4,
                   "line": 7,
@@ -621,7 +621,7 @@ Object {
               "line": 9,
               "offset": 62,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 3,
               "line": 6,
@@ -648,7 +648,7 @@ Object {
           "line": 10,
           "offset": 64,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 6,
@@ -678,7 +678,7 @@ Object {
                   "line": 13,
                   "offset": 97,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 8,
                   "line": 13,
@@ -702,7 +702,7 @@ Object {
               "line": 13,
               "offset": 99,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 3,
               "line": 13,
@@ -728,7 +728,7 @@ Object {
           "line": 15,
           "offset": 102,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 13,
@@ -758,7 +758,7 @@ Object {
                   "line": 19,
                   "offset": 136,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 8,
                   "line": 19,
@@ -783,7 +783,7 @@ Object {
               "line": 19,
               "offset": 138,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 3,
               "line": 19,
@@ -809,7 +809,7 @@ Object {
           "line": 21,
           "offset": 141,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 18,
@@ -840,7 +840,7 @@ Object {
                   "line": 27,
                   "offset": 196,
                 },
-                "inputId": 0,
+                "inputId": 4,
                 "start": Object {
                   "column": 4,
                   "line": 27,
@@ -866,7 +866,7 @@ Object {
               "line": 29,
               "offset": 202,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 4,
               "line": 26,
@@ -893,7 +893,7 @@ Object {
           "line": 30,
           "offset": 204,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 1,
           "line": 26,
@@ -923,7 +923,7 @@ Object {
                   "line": 33,
                   "offset": 240,
                 },
-                "inputId": 0,
+                "inputId": 5,
                 "start": Object {
                   "column": 9,
                   "line": 33,
@@ -947,7 +947,7 @@ Object {
               "line": 33,
               "offset": 242,
             },
-            "inputId": 0,
+            "inputId": 5,
             "start": Object {
               "column": 4,
               "line": 33,
@@ -973,7 +973,7 @@ Object {
           "line": 35,
           "offset": 245,
         },
-        "inputId": 0,
+        "inputId": 5,
         "start": Object {
           "column": 1,
           "line": 33,
@@ -1003,7 +1003,7 @@ Object {
                   "line": 39,
                   "offset": 282,
                 },
-                "inputId": 0,
+                "inputId": 6,
                 "start": Object {
                   "column": 9,
                   "line": 39,
@@ -1028,7 +1028,7 @@ Object {
               "line": 39,
               "offset": 284,
             },
-            "inputId": 0,
+            "inputId": 6,
             "start": Object {
               "column": 4,
               "line": 39,
@@ -1056,7 +1056,7 @@ Object {
           "line": 41,
           "offset": 287,
         },
-        "inputId": 0,
+        "inputId": 6,
         "start": Object {
           "column": 1,
           "line": 38,
@@ -1083,24 +1083,6 @@ exports[`AST tests block-in-list-blockquote.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "    a {
-    user-select: none;
-
-    }
-",
-      "file": "/block-in-list-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "       a {
-       user-select: none;
-
-       }
-",
-      "file": "/block-in-list-blockquote.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Header
 
 ## List in Blockquote
@@ -1118,6 +1100,24 @@ Object {
 >
 >      }
 >      \`\`\`
+",
+      "file": "/block-in-list-blockquote.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "    a {
+    user-select: none;
+
+    }
+",
+      "file": "/block-in-list-blockquote.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "       a {
+       user-select: none;
+
+       }
 ",
       "file": "/block-in-list-blockquote.md",
       "hasBOM": false,
@@ -1146,7 +1146,7 @@ Object {
                   "line": 7,
                   "offset": 73,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 5,
                   "line": 7,
@@ -1172,7 +1172,7 @@ Object {
               "line": 9,
               "offset": 81,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 5,
               "line": 6,
@@ -1209,7 +1209,7 @@ Object {
           "line": 10,
           "offset": 83,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 6,
@@ -1240,7 +1240,7 @@ Object {
                   "line": 14,
                   "offset": 142,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 8,
                   "line": 14,
@@ -1266,7 +1266,7 @@ Object {
               "line": 16,
               "offset": 153,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 8,
               "line": 13,
@@ -1303,7 +1303,7 @@ Object {
           "line": 17,
           "offset": 155,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 13,
@@ -1330,21 +1330,6 @@ exports[`AST tests empty.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "",
-      "file": "/empty.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "",
-      "file": "/empty.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "",
-      "file": "/empty.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Empty
 
 \`\`\`css
@@ -1355,6 +1340,21 @@ Object {
 > \`\`\`css
 > \`\`\`
 ",
+      "file": "/empty.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "",
+      "file": "/empty.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "",
+      "file": "/empty.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "",
       "file": "/empty.md",
       "hasBOM": false,
     },
@@ -1378,7 +1378,7 @@ Object {
           "line": 4,
           "offset": 16,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 4,
@@ -1405,7 +1405,7 @@ Object {
           "line": 6,
           "offset": 28,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 8,
           "line": 6,
@@ -1440,7 +1440,7 @@ Object {
           "line": 9,
           "offset": 47,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 9,
@@ -1467,11 +1467,6 @@ exports[`AST tests frontmatter.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": " .b {}",
-      "file": "/frontmatter.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "---
 style: <style> .a {} </style>
 ---
@@ -1480,6 +1475,11 @@ style: <style> .a {} </style>
 
 <style> .b {} </style>
 ",
+      "file": "/frontmatter.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": " .b {}",
       "file": "/frontmatter.md",
       "hasBOM": false,
     },
@@ -1506,7 +1506,7 @@ style: <style> .a {} </style>
               "line": 7,
               "offset": 66,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 9,
               "line": 7,
@@ -1535,7 +1535,7 @@ style: <style> .a {} </style>
           "line": 7,
           "offset": 67,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 8,
           "line": 7,
@@ -1561,35 +1561,6 @@ style: <style> .a {} </style>
 exports[`AST tests html-in-md.md ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": "a {
-color: red;
-}
-",
-      "file": "/html-in-md.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".b {
-color: red;
-}
-",
-      "file": "/html-in-md.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".c {
-color: red;
-}
-",
-      "file": "/html-in-md.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".d {}",
-      "file": "/html-in-md.md",
-      "hasBOM": false,
-    },
     Object {
       "css": "<div>
 
@@ -1623,6 +1594,35 @@ color: red;
       "file": "/html-in-md.md",
       "hasBOM": false,
     },
+    Object {
+      "css": "a {
+color: red;
+}
+",
+      "file": "/html-in-md.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".b {
+color: red;
+}
+",
+      "file": "/html-in-md.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".c {
+color: red;
+}
+",
+      "file": "/html-in-md.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".d {}",
+      "file": "/html-in-md.md",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -1647,7 +1647,7 @@ color: red;
                   "line": 8,
                   "offset": 37,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 1,
                   "line": 8,
@@ -1672,7 +1672,7 @@ color: red;
               "line": 9,
               "offset": 39,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 7,
@@ -1700,7 +1700,7 @@ color: red;
           "line": 10,
           "offset": 41,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 7,
@@ -1731,7 +1731,7 @@ color: red;
                   "line": 14,
                   "offset": 74,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 1,
                   "line": 14,
@@ -1756,7 +1756,7 @@ color: red;
               "line": 15,
               "offset": 76,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 13,
@@ -1781,7 +1781,7 @@ color: red;
           "line": 16,
           "offset": 78,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 13,
@@ -1812,7 +1812,7 @@ color: red;
                   "line": 22,
                   "offset": 119,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 1,
                   "line": 22,
@@ -1837,7 +1837,7 @@ color: red;
               "line": 23,
               "offset": 121,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 21,
@@ -1864,7 +1864,7 @@ color: red;
           "line": 24,
           "offset": 123,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 21,
@@ -1894,7 +1894,7 @@ color: red;
               "line": 28,
               "offset": 152,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 8,
               "line": 28,
@@ -1921,7 +1921,7 @@ color: red;
           "line": 28,
           "offset": 153,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 8,
           "line": 28,
@@ -1947,38 +1947,6 @@ color: red;
 exports[`AST tests ignore-comment.md ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": ".b {
-  color: red;
-}
-",
-      "file": "/ignore-comment.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".f {
-  color: red;
-}
-",
-      "file": "/ignore-comment.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": ".h {
-  color: red;
-}
-",
-      "file": "/ignore-comment.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "  .i {
-    color: red;
-  }
-",
-      "file": "/ignore-comment.md",
-      "hasBOM": false,
-    },
     Object {
       "css": "# Header
 
@@ -2058,6 +2026,38 @@ a {
       "file": "/ignore-comment.md",
       "hasBOM": false,
     },
+    Object {
+      "css": ".b {
+  color: red;
+}
+",
+      "file": "/ignore-comment.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".f {
+  color: red;
+}
+",
+      "file": "/ignore-comment.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".h {
+  color: red;
+}
+",
+      "file": "/ignore-comment.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "  .i {
+    color: red;
+  }
+",
+      "file": "/ignore-comment.md",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -2082,7 +2082,7 @@ a {
                   "line": 13,
                   "offset": 89,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 13,
@@ -2107,7 +2107,7 @@ a {
               "line": 14,
               "offset": 91,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 12,
@@ -2140,7 +2140,7 @@ a {
           "line": 15,
           "offset": 93,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 12,
@@ -2171,7 +2171,7 @@ a {
                   "line": 46,
                   "offset": 340,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 3,
                   "line": 46,
@@ -2196,7 +2196,7 @@ a {
               "line": 47,
               "offset": 342,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 45,
@@ -2249,7 +2249,7 @@ a {
           "line": 48,
           "offset": 344,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 45,
@@ -2280,7 +2280,7 @@ a {
                   "line": 62,
                   "offset": 467,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 3,
                   "line": 62,
@@ -2305,7 +2305,7 @@ a {
               "line": 63,
               "offset": 469,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 61,
@@ -2340,7 +2340,7 @@ a {
           "line": 64,
           "offset": 471,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 61,
@@ -2371,7 +2371,7 @@ a {
                   "line": 71,
                   "offset": 541,
                 },
-                "inputId": 0,
+                "inputId": 4,
                 "start": Object {
                   "column": 5,
                   "line": 71,
@@ -2396,7 +2396,7 @@ a {
               "line": 72,
               "offset": 545,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 3,
               "line": 70,
@@ -2427,7 +2427,7 @@ a {
           "line": 73,
           "offset": 547,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 1,
           "line": 70,
@@ -2454,17 +2454,17 @@ exports[`AST tests ignore-comment-with-html.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": ".b {color: red;}",
-      "file": "/ignore-comment-with-html.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Ignore Comment with HTML
 
 <!--postcss-ignore-->
 
 <style>.a {color: red;}</style><style>.b {color: red;}</style>
 ",
+      "file": "/ignore-comment-with-html.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": ".b {color: red;}",
       "file": "/ignore-comment-with-html.md",
       "hasBOM": false,
     },
@@ -2491,7 +2491,7 @@ Object {
                   "line": 5,
                   "offset": 103,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 43,
                   "line": 5,
@@ -2515,7 +2515,7 @@ Object {
               "line": 5,
               "offset": 104,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 39,
               "line": 5,
@@ -2542,7 +2542,7 @@ Object {
           "line": 5,
           "offset": 105,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 39,
           "line": 5,
@@ -2595,22 +2595,22 @@ exports[`AST tests inline-html.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "color: red;",
-      "file": "/inline-html.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "color: red;",
-      "file": "/inline-html.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# HTML Inline Styles
 
 <div style=\\"color: red;\\"></div>
 
 <div><div style=\\"color: red;\\"></div></div>
 ",
+      "file": "/inline-html.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: red;",
+      "file": "/inline-html.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "color: red;",
       "file": "/inline-html.md",
       "hasBOM": false,
     },
@@ -2633,7 +2633,7 @@ Object {
               "line": 3,
               "offset": 44,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 13,
               "line": 3,
@@ -2657,7 +2657,7 @@ Object {
           "line": 3,
           "offset": 45,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 13,
           "line": 3,
@@ -2683,7 +2683,7 @@ Object {
               "line": 5,
               "offset": 82,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 18,
               "line": 5,
@@ -2709,7 +2709,7 @@ Object {
           "line": 5,
           "offset": 83,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 18,
           "line": 5,
@@ -2736,26 +2736,6 @@ exports[`AST tests lang-postcss.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "a {
-a {
-color: red
-}
-}
-",
-      "file": "/lang-postcss.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "a {
-a {
-color: red
-}
-}
-",
-      "file": "/lang-postcss.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Lang PostCss
 
 \`\`\`postcss
@@ -2773,6 +2753,26 @@ color: red
 }
 }
 \`\`\`
+",
+      "file": "/lang-postcss.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+a {
+color: red
+}
+}
+",
+      "file": "/lang-postcss.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+a {
+color: red
+}
+}
 ",
       "file": "/lang-postcss.md",
       "hasBOM": false,
@@ -2805,7 +2805,7 @@ color: red
                       "line": 6,
                       "offset": 44,
                     },
-                    "inputId": 0,
+                    "inputId": 1,
                     "start": Object {
                       "column": 1,
                       "line": 6,
@@ -2831,7 +2831,7 @@ color: red
                   "line": 7,
                   "offset": 46,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 1,
                   "line": 5,
@@ -2855,7 +2855,7 @@ color: red
               "line": 8,
               "offset": 48,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 4,
@@ -2880,7 +2880,7 @@ color: red
           "line": 9,
           "offset": 50,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 4,
@@ -2915,7 +2915,7 @@ color: red
                       "line": 14,
                       "offset": 80,
                     },
-                    "inputId": 0,
+                    "inputId": 2,
                     "start": Object {
                       "column": 1,
                       "line": 14,
@@ -2941,7 +2941,7 @@ color: red
                   "line": 15,
                   "offset": 82,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 1,
                   "line": 13,
@@ -2965,7 +2965,7 @@ color: red
               "line": 16,
               "offset": 84,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 12,
@@ -2992,7 +2992,7 @@ color: red
           "line": 17,
           "offset": 86,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 12,
@@ -3019,14 +3019,6 @@ exports[`AST tests nest.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "  a {
-    color: red;
-  }
-",
-      "file": "/nest.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Header
 
 - CSS
@@ -3036,6 +3028,14 @@ Object {
     color: red;
   }
   \`\`\`
+",
+      "file": "/nest.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "  a {
+    color: red;
+  }
 ",
       "file": "/nest.md",
       "hasBOM": false,
@@ -3064,7 +3064,7 @@ Object {
                   "line": 7,
                   "offset": 46,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 5,
                   "line": 7,
@@ -3089,7 +3089,7 @@ Object {
               "line": 8,
               "offset": 50,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 3,
               "line": 6,
@@ -3118,7 +3118,7 @@ Object {
           "line": 9,
           "offset": 52,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 6,
@@ -3145,14 +3145,6 @@ exports[`AST tests no-effect-ignore-comment.md ast 1`] = `
 Object {
   "inputs": Array [
     Object {
-      "css": "a {
-  color: red;
-}
-",
-      "file": "/no-effect-ignore-comment.md",
-      "hasBOM": false,
-    },
-    Object {
       "css": "# Header
 
 <!--postcss-ignore-->
@@ -3164,6 +3156,14 @@ a {
   color: red;
 }
 \`\`\`
+",
+      "file": "/no-effect-ignore-comment.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+  color: red;
+}
 ",
       "file": "/no-effect-ignore-comment.md",
       "hasBOM": false,
@@ -3192,7 +3192,7 @@ a {
                   "line": 9,
                   "offset": 63,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 9,
@@ -3217,7 +3217,7 @@ a {
               "line": 10,
               "offset": 65,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 8,
@@ -3248,7 +3248,7 @@ a {
           "line": 11,
           "offset": 67,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 8,
@@ -3274,36 +3274,6 @@ a {
 exports[`AST tests scss.md ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": "// comment
-a {
-  color: red;
-}
-// comment
-",
-      "file": "/scss.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "// comment
-a {
-  color: red;
-}
-// comment
-",
-      "file": "/scss.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "// comment
-a {
-  color: red;
-}
-// comment
-",
-      "file": "/scss.md",
-      "hasBOM": false,
-    },
     Object {
       "css": "# SCSS
 
@@ -3340,6 +3310,36 @@ a {
       "file": "/scss.md",
       "hasBOM": false,
     },
+    Object {
+      "css": "// comment
+a {
+  color: red;
+}
+// comment
+",
+      "file": "/scss.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "// comment
+a {
+  color: red;
+}
+// comment
+",
+      "file": "/scss.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "// comment
+a {
+  color: red;
+}
+// comment
+",
+      "file": "/scss.md",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -3361,7 +3361,7 @@ a {
               "line": 4,
               "offset": 25,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 4,
@@ -3388,7 +3388,7 @@ a {
                   "line": 6,
                   "offset": 43,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 6,
@@ -3414,7 +3414,7 @@ a {
               "line": 7,
               "offset": 45,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 5,
@@ -3438,7 +3438,7 @@ a {
               "line": 8,
               "offset": 56,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 8,
@@ -3464,7 +3464,7 @@ a {
           "line": 9,
           "offset": 58,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 4,
@@ -3492,7 +3492,7 @@ a {
               "line": 15,
               "offset": 121,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 15,
@@ -3519,7 +3519,7 @@ a {
                   "line": 17,
                   "offset": 139,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 3,
                   "line": 17,
@@ -3545,7 +3545,7 @@ a {
               "line": 18,
               "offset": 141,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 16,
@@ -3569,7 +3569,7 @@ a {
               "line": 19,
               "offset": 152,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 19,
@@ -3599,7 +3599,7 @@ a {
           "line": 20,
           "offset": 154,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 15,
@@ -3627,7 +3627,7 @@ a {
               "line": 26,
               "offset": 214,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 26,
@@ -3654,7 +3654,7 @@ a {
                   "line": 28,
                   "offset": 232,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 3,
                   "line": 28,
@@ -3680,7 +3680,7 @@ a {
               "line": 29,
               "offset": 234,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 27,
@@ -3704,7 +3704,7 @@ a {
               "line": 30,
               "offset": 245,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 30,
@@ -3735,7 +3735,7 @@ a {
           "line": 31,
           "offset": 247,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 26,
@@ -3761,42 +3761,6 @@ a {
 exports[`AST tests test.md ast 1`] = `
 Object {
   "inputs": Array [
-    Object {
-      "css": "a {
-  color: red;
-}
-",
-      "file": "/test.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "a {
-  color: red;
-}
-// comment
-.b {
-  color: red;
-}
-",
-      "file": "/test.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "a {
-  color: red;
-}
-",
-      "file": "/test.md",
-      "hasBOM": false,
-    },
-    Object {
-      "css": "a {
-  color: red;
-}
-",
-      "file": "/test.md",
-      "hasBOM": false,
-    },
     Object {
       "css": "# Header
 
@@ -3837,6 +3801,42 @@ block
       "file": "/test.md",
       "hasBOM": false,
     },
+    Object {
+      "css": "a {
+  color: red;
+}
+",
+      "file": "/test.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+  color: red;
+}
+// comment
+.b {
+  color: red;
+}
+",
+      "file": "/test.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+  color: red;
+}
+",
+      "file": "/test.md",
+      "hasBOM": false,
+    },
+    Object {
+      "css": "a {
+  color: red;
+}
+",
+      "file": "/test.md",
+      "hasBOM": false,
+    },
   ],
   "nodes": Array [
     Object {
@@ -3861,7 +3861,7 @@ block
                   "line": 5,
                   "offset": 33,
                 },
-                "inputId": 0,
+                "inputId": 1,
                 "start": Object {
                   "column": 3,
                   "line": 5,
@@ -3886,7 +3886,7 @@ block
               "line": 6,
               "offset": 35,
             },
-            "inputId": 0,
+            "inputId": 1,
             "start": Object {
               "column": 1,
               "line": 4,
@@ -3911,7 +3911,7 @@ block
           "line": 7,
           "offset": 37,
         },
-        "inputId": 0,
+        "inputId": 1,
         "start": Object {
           "column": 1,
           "line": 4,
@@ -3942,7 +3942,7 @@ block
                   "line": 11,
                   "offset": 66,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 3,
                   "line": 11,
@@ -3967,7 +3967,7 @@ block
               "line": 12,
               "offset": 68,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 10,
@@ -3991,7 +3991,7 @@ block
               "line": 13,
               "offset": 79,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 13,
@@ -4018,7 +4018,7 @@ block
                   "line": 15,
                   "offset": 98,
                 },
-                "inputId": 0,
+                "inputId": 2,
                 "start": Object {
                   "column": 3,
                   "line": 15,
@@ -4044,7 +4044,7 @@ block
               "line": 16,
               "offset": 100,
             },
-            "inputId": 0,
+            "inputId": 2,
             "start": Object {
               "column": 1,
               "line": 14,
@@ -4069,7 +4069,7 @@ block
           "line": 17,
           "offset": 102,
         },
-        "inputId": 0,
+        "inputId": 2,
         "start": Object {
           "column": 1,
           "line": 10,
@@ -4100,7 +4100,7 @@ block
                   "line": 22,
                   "offset": 139,
                 },
-                "inputId": 0,
+                "inputId": 3,
                 "start": Object {
                   "column": 3,
                   "line": 22,
@@ -4125,7 +4125,7 @@ block
               "line": 23,
               "offset": 141,
             },
-            "inputId": 0,
+            "inputId": 3,
             "start": Object {
               "column": 1,
               "line": 21,
@@ -4152,7 +4152,7 @@ block
           "line": 24,
           "offset": 143,
         },
-        "inputId": 0,
+        "inputId": 3,
         "start": Object {
           "column": 1,
           "line": 21,
@@ -4183,7 +4183,7 @@ block
                   "line": 29,
                   "offset": 181,
                 },
-                "inputId": 0,
+                "inputId": 4,
                 "start": Object {
                   "column": 3,
                   "line": 29,
@@ -4208,7 +4208,7 @@ block
               "line": 30,
               "offset": 183,
             },
-            "inputId": 0,
+            "inputId": 4,
             "start": Object {
               "column": 1,
               "line": 28,
@@ -4240,7 +4240,7 @@ block
           "line": 31,
           "offset": 185,
         },
-        "inputId": 0,
+        "inputId": 4,
         "start": Object {
           "column": 1,
           "line": 28,


### PR DESCRIPTION
This updates the `engines` field from `^12 || >=14` to `^22.12 || >=24`, dropping support for Node.js versions that have reached end of life. The CI test matrix now covers 22.12.0 (the minimum supported version), 22.x, and 24.x, and the lint job runs on the latest LTS.

The `eslint-disable` comment for `node/no-unsupported-features/node-builtins` on `module.createRequire` is removed since it is supported by all target versions now.

The AST test snapshots are regenerated because postcss 8.5.25 changed the order in which `toJSON()` collects `inputs` (the document's own input now comes first, followed by the embedded code block inputs). The snapshot diff is only reordering and `inputId` renumbering; no data is added or lost.

This also modernizes the Renovate configuration (`config:recommended`, current `packageRules` option names, and automerge for GitHub Actions / devcontainer updates).

Note: this is a breaking change and should be released as a major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)