### PR TITLE
feat!: migrate to ESM

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,4 @@
+{
+	"reporter": ["lcov", "text"],
+	"check-coverage": true
+}

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,8 +4,8 @@
 
 module.exports = {
 	parserOptions: {
-		sourceType: "script",
-		ecmaVersion: 2020,
+		sourceType: "module",
+		ecmaVersion: 2022,
 	},
 	env: {
 		node: true,
@@ -35,6 +35,26 @@ module.exports = {
 		"prefer-const": "error",
 	},
 	overrides: [
+		{
+			files: ["*.js", "*.mjs"],
+			parserOptions: {
+				sourceType: "module",
+				ecmaVersion: 2022,
+			},
+			rules: {
+				"node/file-extension-in-import": ["error", "always"],
+				"node/no-unsupported-features/es-syntax": [
+					"error",
+					{ ignores: ["modules"] },
+				],
+			},
+		},
+		{
+			files: ["*.cjs"],
+			parserOptions: {
+				sourceType: "script",
+			},
+		},
 		{
 			files: ["test/**/*.js"],
 			rules: {

--- a/README.md
+++ b/README.md
@@ -29,21 +29,28 @@ If you want support SCSS/SASS/LESS/SugarSS syntax, you need to install the corre
 - SugarSS: [sugarss](https://github.com/postcss/sugarss)
 - Stylus: [postcss-styl](https://github.com/ota-meshi/postcss-styl)
 
+This package is written in ESM and requires Node.js `^22.12 || >=24`. CommonJS consumers can still load it with `require("postcss-markdown")` on these Node.js versions (via `require(esm)`).
+
 ## Use Cases
 
 ```js
-const postcss = require("postcss");
-const syntax = require("postcss-markdown")({
+import postcss from "postcss";
+import postcssMarkdown from "postcss-markdown";
+import postcssScss from "postcss-scss";
+import postcssLess from "postcss-less";
+import postcssSafeParser from "postcss-safe-parser";
+import autoprefixer from "autoprefixer";
+
+const syntax = postcssMarkdown({
     // Enable support for HTML (default: true)
     htmlInMd: true,
     // syntax for parse scss (non-required options)
-    scss: require("postcss-scss"),
+    scss: postcssScss,
     // syntax for parse less (non-required options)
-    less: require("postcss-less"),
+    less: postcssLess,
     // syntax for parse css blocks (non-required options)
-    css: require("postcss-safe-parser"),
+    css: postcssSafeParser,
 });
-const autoprefixer = require("autoprefixer");
 postcss([autoprefixer])
     .process(source, { syntax: syntax })
     .then(function (result) {
@@ -93,6 +100,12 @@ If you want support SCSS/SASS/LESS/SugarSS syntax, you need to install these mod
 ### Options
 
 ```js
+import { createRequire } from "module";
+import postcssMarkdown from "postcss-markdown";
+import postcssSass from "postcss-sass";
+import sugarss from "sugarss";
+import postcssCustomSyntax from "postcss-custom-syntax";
+
 const options = {
     rules: [
         {
@@ -110,17 +123,17 @@ const options = {
     // custom parser for CSS (using `postcss-safe-parser`)
     css: "postcss-safe-parser",
     // custom parser for SASS (PostCSS-compatible syntax.)
-    sass: require("postcss-sass"),
+    sass: postcssSass,
     // custom parser for SCSS (by module name)
     scss: "postcss-scss",
     // custom parser for LESS (by module path)
-    less: require.resolve("./node_modules/postcss-less"),
+    less: createRequire(import.meta.url).resolve("postcss-less"),
     // custom parser for SugarSS
-    sugarss: require("sugarss"),
+    sugarss: sugarss,
     // custom parser for custom language
-    custom: require("postcss-custom-syntax"),
+    custom: postcssCustomSyntax,
 };
-const syntax = require("postcss-markdown")(options);
+const syntax = postcssMarkdown(options);
 ```
 
 ## Turning PostCSS off from within your Markdown

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const parse = require("./parse");
-const stringify = require("./stringify");
+import parse from "./parse.js";
+import stringify from "./stringify.js";
 
 function postcssMarkdown(config) {
 	const syntax = {
@@ -16,4 +14,5 @@ const defaultSyntax = postcssMarkdown();
 postcssMarkdown.parse = defaultSyntax.parse;
 postcssMarkdown.stringify = defaultSyntax.stringify;
 
-module.exports = postcssMarkdown;
+export default postcssMarkdown;
+export { postcssMarkdown as "module.exports" };

--- a/lib/markdown/document.js
+++ b/lib/markdown/document.js
@@ -1,14 +1,9 @@
-"use strict";
-
-const { Document: PostCssDocument } = require("postcss");
+import { Document as PostCssDocument } from "postcss";
+import stringify from "../stringify.js";
 
 class Document extends PostCssDocument {
 	toString(stringifier) {
-		return super.toString(
-			stringifier || {
-				stringify: require("../stringify"),
-			},
-		);
+		return super.toString(stringifier || { stringify });
 	}
 
 	each(callback) {
@@ -36,4 +31,4 @@ class Document extends PostCssDocument {
 		return this;
 	}
 }
-module.exports = Document;
+export default Document;

--- a/lib/markdown/extract-styles.js
+++ b/lib/markdown/extract-styles.js
@@ -1,9 +1,7 @@
-"use strict";
-
-const fromMarkdown = require("mdast-util-from-markdown");
-const frontmatter = require("mdast-util-frontmatter");
-const syntax = require("micromark-extension-frontmatter");
-const buildSyntaxResolver = require("../syntax/build-syntax-resolver");
+import fromMarkdown from "mdast-util-from-markdown";
+import frontmatter from "mdast-util-frontmatter";
+import syntax from "micromark-extension-frontmatter";
+import buildSyntaxResolver from "../syntax/build-syntax-resolver.js";
 
 function extractStyles(source, opts) {
 	const resolveSyntax = buildSyntaxResolver(opts.config);
@@ -123,7 +121,7 @@ function extractStyles(source, opts) {
 	return styles;
 }
 
-module.exports = extractStyles;
+export default extractStyles;
 
 function visit(node, callback) {
 	const nodes = [{ node, parent: null, index: 0 }];

--- a/lib/markdown/parse-styles.js
+++ b/lib/markdown/parse-styles.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const Input = require("postcss/lib/input");
-const Document = require("./document");
+import { Input } from "postcss";
+import Document from "./document.js";
 
 const reNewLine = /\r?\n|\r/g;
 
@@ -235,7 +233,7 @@ function parseStyles(source, opts, styles) {
 	return document;
 }
 
-module.exports = parseStyles;
+export default parseStyles;
 
 function patchRoot(root, syntax) {
 	const originalToString = root.toString;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,11 +1,9 @@
-"use strict";
+import extract from "./markdown/extract-styles.js";
+import parseStyles from "./markdown/parse-styles.js";
 
-const extract = require("./markdown/extract-styles");
-const parseStyles = require("./markdown/parse-styles");
-
-module.exports = function parse(source, opts) {
+export default function parse(source, opts) {
 	const document = parseStyles(source, opts, extract(source, opts));
 	document.source.lang = "markdown";
 	document.source.syntax = opts.syntax;
 	return document;
-};
+}

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1,9 +1,5 @@
-"use strict";
-
-const postcssStringify = require("postcss/lib/stringify");
-const Document = require("./markdown/document");
-
-module.exports = stringify;
+import { stringify as postcssStringify } from "postcss";
+import Document from "./markdown/document.js";
 
 class CustomAppender {
 	constructor(baseBuilder) {
@@ -100,7 +96,7 @@ class CustomAppender {
 	}
 }
 
-function stringify(node, builder) {
+export default function stringify(node, builder) {
 	if (!(node instanceof Document)) {
 		const syntax = node.source.syntax || node.root().source.syntax;
 		if (syntax && syntax.stringify) {

--- a/lib/syntax/build-syntax-resolver.js
+++ b/lib/syntax/build-syntax-resolver.js
@@ -1,8 +1,7 @@
-"use strict";
-
-const path = require("path");
-const postcssSafeParser = require("postcss-safe-parser");
-const { cssSyntax, cssSafeSyntax } = require("./syntaxes");
+import { createRequire } from "module";
+import path from "path";
+import postcssSafeParser from "postcss-safe-parser";
+import { cssSyntax, cssSafeSyntax } from "./syntaxes.js";
 
 const defaultRules = [
 	{
@@ -42,7 +41,7 @@ const defaultSyntaxes = {
 	xml: "postcss-html",
 };
 
-module.exports = function buildSyntaxResolver(config) {
+export default function buildSyntaxResolver(config) {
 	const { rules = [], htmlInMd: _htmlInMd, ...syntaxes } = config || {};
 	const allRules = [...rules, ...defaultRules];
 
@@ -93,21 +92,17 @@ module.exports = function buildSyntaxResolver(config) {
 
 		return cssSyntax;
 	};
-};
+}
+
+const localRequire = createRequire(import.meta.url);
 
 const standardModuleResolvers = {
-	// eslint-disable-next-line node/no-missing-require -- ignore
-	"postcss-sass": () => require("postcss-sass"),
-	// eslint-disable-next-line node/no-unpublished-require -- ignore
-	"postcss-scss": () => require("postcss-scss"),
-	// eslint-disable-next-line node/no-unpublished-require -- ignore
-	"postcss-less": () => require("postcss-less"),
-	// eslint-disable-next-line node/no-unpublished-require -- ignore
-	sugarss: () => require("sugarss"),
-	// eslint-disable-next-line node/no-unpublished-require -- ignore
-	"postcss-styl": () => require("postcss-styl"),
-	// eslint-disable-next-line node/no-unpublished-require -- ignore
-	"postcss-html": () => require("postcss-html"),
+	"postcss-sass": () => localRequire("postcss-sass"),
+	"postcss-scss": () => localRequire("postcss-scss"),
+	"postcss-less": () => localRequire("postcss-less"),
+	sugarss: () => localRequire("sugarss"),
+	"postcss-styl": () => localRequire("postcss-styl"),
+	"postcss-html": () => localRequire("postcss-html"),
 };
 
 function loadFromString(syntax) {
@@ -119,10 +114,9 @@ function loadFromString(syntax) {
 	}
 
 	try {
-		const m = require("module");
 		const cwd = process.cwd();
 		const relativeTo = path.join(cwd, "__placeholder__.js");
-		return m.createRequire(relativeTo)(syntax);
+		return createRequire(relativeTo)(syntax);
 	} catch (error) {
 		if (!isModuleNotFoundError(error)) {
 			throw error;

--- a/lib/syntax/syntaxes.js
+++ b/lib/syntax/syntaxes.js
@@ -1,15 +1,11 @@
-"use strict";
+import { parse as postcssParse, stringify as postcssStringify } from "postcss";
+import postcssSafeParser from "postcss-safe-parser";
 
-const postcssParse = require("postcss/lib/parse");
-const postcssStringify = require("postcss/lib/stringify");
-const postcssSafeParser = require("postcss-safe-parser");
-
-const cssSyntax = {
+export const cssSyntax = {
 	parse: postcssParse,
 	stringify: postcssStringify,
 };
-const cssSafeSyntax = {
+export const cssSafeSyntax = {
 	parse: postcssSafeParser,
 	stringify: postcssStringify,
 };
-module.exports = { cssSyntax, cssSafeSyntax };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
   "engines": {
     "node": "^22.12 || >=24"
   },
+  "type": "module",
   "main": "./lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "lib"
   ],
@@ -37,17 +42,9 @@
     "url": "https://github.com/ota-meshi/postcss-markdown/issues"
   },
   "homepage": "https://github.com/ota-meshi/postcss-markdown#readme",
-  "nyc": {
-    "reporter": [
-      "lcov",
-      "text"
-    ],
-    "cache": true,
-    "check-coverage": true
-  },
   "scripts": {
     "mocha": "mocha \"test/**/*.js\" --no-timeouts",
-    "test": "nyc npm run mocha",
+    "test": "c8 npm run mocha",
     "lint": "eslint .",
     "eslint-fix": "eslint . --fix",
     "preversion": "npm run test",
@@ -63,6 +60,7 @@
   "devDependencies": {
     "@ota-meshi/eslint-plugin": "^0.13.0",
     "autoprefixer": "^10.3.7",
+    "c8": "^12.0.0",
     "chai": "^4.2.0",
     "codecov": "^3.8.1",
     "eslint": "^8.0.0",
@@ -77,7 +75,6 @@
     "eslint-plugin-yml": "^1.0.0",
     "mocha": "^10.0.0",
     "mocha-chai-jest-snapshot": "1.1.3",
-    "nyc": "^15.1.0",
     "postcss-html": "^1.3.0",
     "postcss-less": "^6.0.0",
     "postcss-scss": "^4.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,4 @@
-"use strict";
-
-module.exports = {
+export default {
 	tabWidth: 2,
 	semi: true,
 	useTabs: true,

--- a/test/ast.js
+++ b/test/ast.js
@@ -1,14 +1,15 @@
-"use strict";
-
-const path = require("path");
-const chai = require("chai");
-const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
-const syntax = require("../");
-const { listupFixtures } = require("./utils");
+import path from "path";
+import * as chai from "chai";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
+import syntax from "../lib/index.js";
+import { listupFixtures } from "./utils.js";
 
 chai.use(jestSnapshotPlugin());
 
-const AST_FIXTURE_ROOT = path.resolve(__dirname, "../test-fixtures/ast");
+const AST_FIXTURE_ROOT = path.resolve(
+	import.meta.dirname,
+	"../test-fixtures/ast",
+);
 
 describe("AST tests", () => {
 	for (const { filename, content } of listupFixtures(AST_FIXTURE_ROOT)) {

--- a/test/backward-compat.js
+++ b/test/backward-compat.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const expect = require("chai").expect;
-const syntax = require("../");
+import { expect } from "chai";
+import syntax from "../lib/index.js";
 
 describe("backward compatible tests", () => {
 	it("Config", () => {

--- a/test/document-api.js
+++ b/test/document-api.js
@@ -1,9 +1,6 @@
-"use strict";
-
-const expect = require("chai").expect;
-
-const postcss = require("postcss");
-const syntax = require("../");
+import { expect } from "chai";
+import postcss from "postcss";
+import syntax from "../lib/index.js";
 
 describe("api tests", () => {
 	it("stringify for append node", () => {

--- a/test/error.js
+++ b/test/error.js
@@ -1,8 +1,6 @@
-"use strict";
-
-const path = require("path");
-const expect = require("chai").expect;
-const syntax = require("../");
+import path from "path";
+import { expect } from "chai";
+import syntax from "../lib/index.js";
 
 describe("error tests", () => {
 	it("single line syntax error", () => {
@@ -93,7 +91,7 @@ describe("error tests", () => {
 			"```",
 		].join("\n");
 		const parser = syntax({
-			foo: path.join(__dirname, "./error-test-module.txt"),
+			foo: path.join(import.meta.dirname, "./error-test-module.txt"),
 		});
 		expect(() =>
 			parser.parse(md, {

--- a/test/html-issue146.js
+++ b/test/html-issue146.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const chai = require("chai");
-const syntax = require("../");
+import * as chai from "chai";
+import syntax from "../lib/index.js";
 
 // https://github.com/ota-meshi/postcss-html/issues/146
 describe("issue 146 test", () => {

--- a/test/integration/autoprefixer.js
+++ b/test/integration/autoprefixer.js
@@ -1,17 +1,15 @@
-"use strict";
-
-const path = require("path");
-const chai = require("chai");
-const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
-const autoprefixer = require("autoprefixer");
-const postcss = require("postcss");
-const { listupFixtures } = require("../utils");
-const syntax = require("../..");
+import path from "path";
+import autoprefixer from "autoprefixer";
+import * as chai from "chai";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
+import postcss from "postcss";
+import syntax from "../../lib/index.js";
+import { listupFixtures } from "../utils.js";
 
 chai.use(jestSnapshotPlugin());
 
 const FIXTURE_ROOT = path.resolve(
-	__dirname,
+	import.meta.dirname,
 	"../../test-fixtures/integration/autoprefixer",
 );
 

--- a/test/integration/stylelint.js
+++ b/test/integration/stylelint.js
@@ -1,17 +1,17 @@
-"use strict";
+import { createRequire } from "module";
+import path from "path";
+import * as chai from "chai";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
+import stylelint from "stylelint";
+import stylelintConfig from "stylelint-config-standard";
+import { listupFixtures } from "../utils.js";
 
-const path = require("path");
-const chai = require("chai");
-const { jestSnapshotPlugin } = require("mocha-chai-jest-snapshot");
-const stylelint = require("stylelint");
-const stylelintConfig = require("stylelint-config-standard");
-const { listupFixtures } = require("../utils");
-const customSyntax = require.resolve("../..");
+const customSyntax = createRequire(import.meta.url).resolve("../..");
 
 chai.use(jestSnapshotPlugin());
 
 const FIXTURE_ROOT = path.resolve(
-	__dirname,
+	import.meta.dirname,
 	"../../test-fixtures/integration/stylelint",
 );
 

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const expect = require("chai").expect;
-const syntax = require("../");
+import { expect } from "chai";
+import syntax from "../lib/index.js";
 
 describe("markdown tests", () => {
 	const md = [

--- a/test/root.js
+++ b/test/root.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const expect = require("chai").expect;
-const syntax = require("../");
+import { expect } from "chai";
+import syntax from "../lib/index.js";
 
 describe("Root node tests", () => {
 	it("toString", () => {

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -1,7 +1,7 @@
-"use strict";
-
-const expect = require("chai").expect;
-const syntax = require("../");
+import { expect } from "chai";
+import postcssScss from "postcss-scss";
+import postcssStyl from "postcss-styl";
+import syntax from "../lib/index.js";
 
 describe("syntax option tests", () => {
 	it("syntax option", () => {
@@ -17,8 +17,8 @@ describe("syntax option tests", () => {
 			"```",
 		].join("\n");
 		const document = syntax({
-			s: require("postcss-styl"),
-			css: require("postcss-scss"),
+			s: postcssStyl,
+			css: postcssScss,
 		}).parse(md, {
 			from: "markdown.md",
 		});
@@ -59,8 +59,8 @@ describe("syntax option tests", () => {
 			"</style>",
 		].join("\n");
 		const document = syntax({
-			s: require("postcss-styl"),
-			css: require("postcss-scss"),
+			s: postcssStyl,
+			css: postcssScss,
 		}).parse(md, {
 			from: "markdown.md",
 		});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,7 @@
-"use strict";
+import fs from "fs";
+import path from "path";
 
-const path = require("path");
-const fs = require("fs");
-
-module.exports = { listupFixtures };
-
-function* listupFixtures(rootDir) {
+export function* listupFixtures(rootDir) {
 	for (const filename of fs.readdirSync(rootDir)) {
 		const filepath = path.join(rootDir, filename);
 		if (fs.statSync(filepath).isDirectory()) {


### PR DESCRIPTION
This migrates the package from CommonJS to ESM (`"type": "module"`), building on the Node.js `^22.12 || >=24` requirement from #102.

CommonJS consumers are still supported: since all supported Node.js versions can `require()` ESM modules, the entry point declares `export { postcssMarkdown as \"module.exports\" }` so that `require(\"postcss-markdown\")` keeps returning the same callable syntax object as before. This keeps string-based `customSyntax: \"postcss-markdown\"` in Stylelint configs working, which is covered by the existing stylelint integration test.

Notable changes beyond the mechanical require/import conversion:

- An `exports` field now maps `.` and `./package.json`; deep imports of internal `lib/` files are no longer possible.
- Dynamic syntax module loading keeps using `createRequire`, so user-installed syntaxes resolve from the working directory as before (and `require(esm)` also allows ESM-only syntax modules now).
- The lazy `require(\"../stringify\")` in `Document#toString` (a circular-dependency workaround) is now a static import; the ESM module cycle between `stringify.js` and `document.js` is safe because each binding is only used at call time.
- Coverage moved from nyc to c8, since nyc cannot instrument ES modules.
- `.eslintrc.js` was renamed to `.eslintrc.cjs` and configured for ESM (`sourceType: module`, `.js` extensions required in imports, ES2022 for the `\"module.exports\"` arbitrary export name).
- README examples are updated to ESM.

Note: this is a breaking change and should be released as a major version together with #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)