### PR TITLE
feat!: move postcss to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
     "mdast-util-from-markdown": "^0.8.5",
     "mdast-util-frontmatter": "^0.2.0",
     "micromark-extension-frontmatter": "^0.2.2",
-    "postcss": "^8.5.0",
     "postcss-safe-parser": "^6.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.5.0"
   },
   "devDependencies": {
     "@ota-meshi/eslint-plugin": "^0.13.0",
@@ -75,6 +77,7 @@
     "eslint-plugin-yml": "^1.0.0",
     "mocha": "^10.0.0",
     "mocha-chai-jest-snapshot": "1.1.7",
+    "postcss": "^8.5.0",
     "postcss-html": "^1.3.0",
     "postcss-less": "^6.0.0",
     "postcss-scss": "^4.0.0",


### PR DESCRIPTION
This moves `postcss` from `dependencies` to `peerDependencies` (`^8.5.0`), and adds it to `devDependencies` for local development and CI.

As a PostCSS syntax, this package should share a single `postcss` instance with the host tool (PostCSS itself, Stylelint, etc.). Declaring it as a peer dependency avoids duplicated `postcss` installations, which can cause subtle issues like `instanceof` checks failing across copies.

npm 7+ installs peer dependencies automatically, so most consumers are unaffected. Package managers that don't auto-install peers need an explicit `postcss` dependency, so this should go into the upcoming major release together with #102 and #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)