### PR TITLE
feat: update dependencies to the latest versions

### DIFF
--- a/lib/markdown/extract-styles.js
+++ b/lib/markdown/extract-styles.js
@@ -1,6 +1,6 @@
-import fromMarkdown from "mdast-util-from-markdown";
-import frontmatter from "mdast-util-frontmatter";
-import syntax from "micromark-extension-frontmatter";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { frontmatterFromMarkdown } from "mdast-util-frontmatter";
+import { frontmatter } from "micromark-extension-frontmatter";
 import buildSyntaxResolver from "../syntax/build-syntax-resolver.js";
 
 function extractStyles(source, opts) {
@@ -9,8 +9,8 @@ function extractStyles(source, opts) {
 	const htmlInMd = (opts.config && opts.config.htmlInMd) !== false;
 
 	const ast = fromMarkdown(source, {
-		extensions: [syntax(["yaml", "toml"])],
-		mdastExtensions: [frontmatter.fromMarkdown(["yaml", "toml"])],
+		extensions: [frontmatter(["yaml", "toml"])],
+		mdastExtensions: [frontmatterFromMarkdown(["yaml", "toml"])],
 	});
 	const styles = [];
 

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "update-snap": "mocha \"test/**/*.js\" --no-timeouts --update"
   },
   "dependencies": {
-    "mdast-util-from-markdown": "^0.8.5",
-    "mdast-util-frontmatter": "^0.2.0",
-    "micromark-extension-frontmatter": "^0.2.2",
-    "postcss-safe-parser": "^6.0.0"
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-frontmatter": "^2.0.1",
+    "micromark-extension-frontmatter": "^2.0.0",
+    "postcss-safe-parser": "^7.0.1"
   },
   "peerDependencies": {
     "postcss": "^8.5.0"


### PR DESCRIPTION
This updates the runtime dependencies to their latest majors, which is now possible because the package is ESM (#103):

- `mdast-util-from-markdown` `^0.8.5` → `^2.0.3`
- `mdast-util-frontmatter` `^0.2.0` → `^2.0.1`
- `micromark-extension-frontmatter` `^0.2.2` → `^2.0.0`
- `postcss-safe-parser` `^6.0.0` → `^7.0.1`

The mdast/micromark packages are ESM-only and renamed their entry points to named exports (`fromMarkdown`, `frontmatterFromMarkdown`, `frontmatter`), so `extract-styles.js` is adjusted accordingly. `postcss-safe-parser` v7 declares `postcss` as a peer dependency, which is already satisfied through this package's own `postcss` peer (#105).

All existing tests, including the AST snapshots, pass unchanged with the new markdown parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)